### PR TITLE
Fixed timeout accidentally causing event loop deferral

### DIFF
--- a/server.js
+++ b/server.js
@@ -76,9 +76,13 @@ var Server = function() {
               for(var header in mock.headers) {
                   res.header(header, mock.headers[header]);
               }
-              setTimeout(function() {
-                res.status(mock.status).send(mock.response);
-              }, mock.timeout * 1000);
+              if(mock.timeout > 0) {
+                setTimeout(function() {
+                  res.status(mock.status).send(mock.response);
+                }, mock.timeout * 1000);
+              } else {
+                  res.status(mock.status).send(mock.response);
+              }
           } else {
               res.status(404).send({});
           }


### PR DESCRIPTION
Fixed a bug where a response can be deferred on the event loop via timeout(fx, 0) (Similar to process.nextTick()). This was causing sync problems in functional testing.
