### PR TITLE
Add support for request filters on lastRequests

### DIFF
--- a/lib/remote-api.js
+++ b/lib/remote-api.js
@@ -27,8 +27,14 @@ module.exports = {
       .end(function(err, res) {
         if (callback) callback(err, res)
       });
+  },
+
+  lastRequests: function(method, path, callback) {
+    superagent.get("http://localhost:7001/lastRequests")
+      .set('method', method)
+      .set('path', path)
+      .end(function(err, res) {
+        if (callback) callback(err, res)
+      });
   }
-
 };
-
-

--- a/lib/requestStore.js
+++ b/lib/requestStore.js
@@ -32,8 +32,15 @@ var RequestStore = {
         }
     },
 
-    returnLastRequests: function () {
-        return lastRequests;
+    returnLastRequests: function (httpMethod, path) {
+      console.log(lastRequests);
+        return lastRequests
+          .filter(function(request) {
+            return httpMethod ? request.method === httpMethod : true;
+          })
+          .filter(function(request) {
+            return path ? request.path === path : true;
+          });
     },
 
     find: function(httpMethod, path) {

--- a/lib/requestStore.js
+++ b/lib/requestStore.js
@@ -33,7 +33,6 @@ var RequestStore = {
     },
 
     returnLastRequests: function (httpMethod, path) {
-      console.log(lastRequests);
         return lastRequests
           .filter(function(request) {
             return httpMethod ? request.method === httpMethod : true;

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ var Server = function() {
   });
 
   app.get('/lastRequests', function(request, res) {
-    res.send(requestStore.returnLastRequests());
+    res.send(requestStore.returnLastRequests(request.headers.method, request.headers.path));
   });
 
   app.get('/lastRequest', function(request, res) {

--- a/test/lastRequestsEndpointTest.js
+++ b/test/lastRequestsEndpointTest.js
@@ -3,29 +3,111 @@ var chai = require('chai').should();
 var expect = require('chai').expect
 var superagent = require('superagent');
 
+var baseUri = 'http://localhost:7000/';
+
 describe('Simulado requests', function() {
 
-  beforeEach(function(done) {
-    superagent.del('http://localhost:7000/clearLastRequests').end(done);
-  });
+  describe('lastRequests', function() {
 
-  it('should return the last requests', function (done) {
-      Simulado.mock({
-          path:'/myPath',
-      }, function(){
-          superagent.get('http://localhost:7000/myPath')
-          .end(function() {
-            superagent.get('http://localhost:7000/myPath')
-              .end(function() {
-                superagent.get('http://localhost:7000/lastRequests')
-                  .end(function(_, res) {
-                    res.body.length.should.eq(2);
-                    done()
-                  });
+    var path1 = 'path1';
+    var path2 = 'path2';
 
-              });
-          });
+    function clearLastRequests(done) {
+      superagent
+        .del(baseUri + 'clearLastRequests')
+        .end(done);
+    }
+
+    beforeEach(function(done) {
+
+      var mocks = [{
+        path: path1
+      }, {
+        path: path1,
+        method: 'POST'
+      }, {
+        path: path2
+      }]
+
+      var count = 0;
+
+      mocks.forEach(function(mock) {
+        Simulado.mock(mock, runTest.bind(this));
       });
-  });
 
+      function runTest() {
+        if (count === mocks.length - 1) {
+          done()
+        } else {
+          count++;
+        }
+      }
+    });
+
+    afterEach(function(done) { clearLastRequests(done); });
+
+    var tests = [
+      {
+        name: 'should return the last requests for the corresponding GET method and path',
+        requests: [{ method: 'GET', path: path1 }, { method: 'GET', path: path2 }],
+        lastRequestsQuery: { method: 'GET', path: path1 },
+        expectations: { lastRequestsCount: 1 }
+      },
+      {
+        name: 'should return the last requests for the corresponding POST method and path',
+        requests: [{ method: 'GET', path: path1 }, { method: 'POST', path: path1 }, { method: 'POST', path: path1 }],
+        lastRequestsQuery: { method: 'POST', path: path1 },
+        expectations: { lastRequestsCount: 2 }
+      },
+      {
+        name: 'should return the last requests for the corresponding method only',
+        requests: [{ method: 'GET', path: path1 }, { method: 'POST', path: path1 }, { method: 'POST', path: path1 }],
+        lastRequestsQuery: { method: 'POST' },
+        expectations: { lastRequestsCount: 2 }
+      },
+      {
+        name: 'should return the last requests for the corresponding path only',
+        requests: [{ method: 'GET', path: path2 }, { method: 'POST', path: path1 }, { method: 'GET', path: path1 }],
+        lastRequestsQuery: { path: path1 },
+        expectations: { lastRequestsCount: 2 }
+      },
+      {
+        name: 'should return all last requests',
+        requests: [{ method: 'GET', path: path2 }, { method: 'POST', path: path1 }, { method: 'GET', path: path1 }],
+        lastRequestsQuery: {},
+        expectations: { lastRequestsCount: 3 }
+      }
+    ];
+
+    tests.forEach(function(test) {
+
+      it(test.name, function(done) {
+
+        var count = 0;
+
+        test.requests.forEach(function(request){
+            superagent[request.method.toLowerCase()](baseUri + request.path).end(runAssertions);
+        })
+
+        function runAssertions(_, res) {
+          if (count === test.requests.length - 1) {
+
+            var requestHeaders = {};
+            if (test.lastRequestsQuery.path) requestHeaders.path = test.lastRequestsQuery.path;
+            if (test.lastRequestsQuery.method) requestHeaders.method = test.lastRequestsQuery.method;
+
+            superagent
+              .get(baseUri + 'lastRequests')
+              .set(requestHeaders)
+              .end(function(err, res) {
+                res.body.length.should.eq(test.expectations.lastRequestsCount);
+                done();
+              });
+          } else {
+            count++;
+          }
+        }
+      });
+    });
+  });
 });

--- a/test/remote-api-test.js
+++ b/test/remote-api-test.js
@@ -42,6 +42,15 @@ describe("Remote API", function() {
     });
   });
 
+  it("should call lastRequests", function(done) {
+    var lastRequestsData = {data: "info"};
 
+    var scope = nock('http://localhost:7001',  { method: 'POST', path: '/' }).get('/lastRequests').reply(204, lastRequestsData);
 
+    api.lastRequests("POST", "/", function(err, res) {
+      expect(res.body).to.deep.eq(lastRequestsData);
+      scope.done();
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Removes redundant test. Does not change any existing functionality.

You can optionally add 'method' and/or 'path' headers to the request now in the same way as other endpoints.
