### PR TITLE
Default mock via cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ simulado
 # otherwise
 ./node_modules/simulado/bin/simulado
 ```
+### Default Mocks on startup
+You can pass the location of a default mocks json file on startup adding them to Simulado straight away.
+```
+simulado ./defaultMocks.json
+```
 ### Require
     var Simulado = require('simulado');
 

--- a/bin/simulado
+++ b/bin/simulado
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
 var Server = require('../server');
+var fs = require('fs');
 
-new Server().start(process.env.PORT || 7001);
+var server = new Server()
+
+if (process.argv[2]) {
+  var defaultResponsesJSON = fs.readFileSync(process.argv[2]);
+  var defaultResponses = JSON.parse(defaultResponsesJSON);
+  server.defaults(defaultResponses);
+}
+
+server.start(process.env.PORT || 7001);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "mocha": "^2.2.5",
     "nock": "^5.2.1",
     "zombie": "^5.0.5"
+    "sinon": "^1.17.6"
   },
   "dependencies": {
     "async": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "chai-spies": "^0.7.1",
     "mocha": "^2.2.5",
     "nock": "^5.2.1",
-    "zombie": "^5.0.5"
+    "zombie": "^5.0.5",
     "sinon": "^1.17.6"
   },
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -109,9 +109,7 @@ var Server = function() {
   };
 
   this.defaults = function(defaultResponses) {
-    defaultResponses.forEach(function(response) {
-      responseStore.add(response);
-    });
+    responseStore.defaults(defaultResponses);
   }
 };
 

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
- var express = require('express');
+var express = require('express');
 var app = express();
 var bodyParser = require('body-parser');
 var cors = require('cors');
@@ -16,7 +16,6 @@ var Server = function() {
   app.set('views', __dirname + '/views');
   app.engine('ejs', require('ejs').__express);
   app.set('view engine','ejs');
-
 
   app.get('/', function(_, res) {
       res.render("index.ejs", { responses: responseStore.getAll(), requests: requestStore.getAll() });
@@ -108,6 +107,12 @@ var Server = function() {
   this.stop = function(callback) {
     this.server.close(callback);
   };
+
+  this.defaults = function(defaultResponses) {
+    defaultResponses.forEach(function(response) {
+      responseStore.add(response);
+    });
+  }
 };
 
 module.exports = Server;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -60,7 +60,7 @@ describe('Simulado end to end', function() {
 
   });
 
-  describe('defaults', () => {
+  describe('defaults', function() {
     var sandbox, responseStoreAddStub;
 
     beforeEach(function() {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2,11 +2,13 @@ var api = require('../lib/remote-api.js');
 var chai = require('chai').should();
 var expect = require('chai').expect;
 var superagent = require('superagent');
-var server = require('../server.js');
+var Server = require('../server.js');
+var responseStore = require('../lib/responseStore');
+var sinon = require('sinon');
 
 describe('Simulado end to end', function() {
   before(function(done) {
-    new server().start(7001);
+    new Server().start(7001);
     done();
   });
 
@@ -58,5 +60,31 @@ describe('Simulado end to end', function() {
 
   });
 
+  describe('defaults', () => {
+    var sandbox, responseStoreAddStub;
+
+    beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+      responseStoreAddStub = sandbox.stub(responseStore, 'add');
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it('should add a default response to the response store', function() {
+      var server = new Server();
+      var defaultMocks = [{ path: '/test' }];
+      server.defaults(defaultMocks);
+      expect(responseStoreAddStub.calledWith(defaultMocks[0])).to.equal(true);
+    });
+
+    it('should add multiple mocks to the response store', function() {
+      var server = new Server();
+      var defaultMocks = [{ path: '/test' }, { path: '/anotherMock'} ];
+      server.defaults(defaultMocks);
+      expect(responseStoreAddStub.calledTwice).to.equal(true);
+    });
+  });
 });
 


### PR DESCRIPTION
Ability to pass `defaultMocks.json` via the command line on startup.

Usage:

```
simulado <PATH_TO_DEFAULT_MOCKS_FILE>
```
## ******\* Possible improvement *******

Instead of specifying it as an argument a flag could be used instead. E.g. `--defaultMocks ./defaultMocks.json`
