### PR TITLE
Add CORS option for request origin default to be localhost 

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,10 +8,9 @@ var path = require('path');
 
 var Server = function() {
   app.use(cors({
-  origin: 'http://localhost:3030',
-  credentials: true,
-  optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
-}));
+    origin: 'http://localhost',
+    credentials: true
+  }));
   app.use(bodyParser.json({limit: '1mb'}));
   app.use(bodyParser.urlencoded({
       extended: true

--- a/server.js
+++ b/server.js
@@ -7,7 +7,11 @@ var requestStore = require('./lib/requestStore');
 var path = require('path');
 
 var Server = function() {
-  app.use(cors());
+  app.use(cors({
+  origin: 'http://localhost:3030',
+  credentials: true,
+  optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
+}));
   app.use(bodyParser.json({limit: '1mb'}));
   app.use(bodyParser.urlencoded({
       extended: true
@@ -69,14 +73,15 @@ var Server = function() {
       res.sendStatus(200);
     });
   });
-  
+
   app.post('/reset', function(req, res) {
     responseStore.reset(req.body, function() {
       res.sendStatus(200);
     });
-  });  
+  });
 
   app.all('*', function(req, res) {
+      res.set('Access-Control-Allow-Origin', req.get('origin'))
       responseStore.find(req, function(mock) {
           if (mock) {
               if (mock.once) { responseStore.remove(mock) }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -60,6 +60,16 @@ describe('Simulado end to end', function() {
 
   });
 
+  describe('CORS', function () {
+    it('should set response header "Access-Control-Allow-Origin" to localhost', function (done) {
+      superagent.get('http://localhost:7001')
+      .end(function(_, res) {
+        expect(res.header['access-control-allow-origin']).to.equal('http://localhost');
+        done()
+      });
+    });
+  });
+
   describe('defaults', function() {
     var sandbox, responseStoreAddStub;
 


### PR DESCRIPTION
When using an endpoint which needed the `credentials` flag to be `true`, requests fail as the origin cannot be a wildcard.

This PR changes the default origin to be `http://localhost`.

```
the .withCredentials() method enables the ability to send cookies from the origin, however only when Access-Control-Allow-Origin is not a wildcard ("*"), and Access-Control-Allow-Credentials is "true".
```