### PR TITLE
Improve path parsing to manage stringified regex (with restrictions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Simulado.mock({
   }
 })
 ```
+Note: Do not use a slash both at the beginning and at the end of the path. It will be parsed as regex otherwise.
 
 ##### Wildcards
 ```javascript
@@ -78,7 +79,21 @@ Simulado.mock({
   }
 })
 ```
-Note: Regex are not supported when using a json file. Please consider using plain javascript objects.
+
+Or
+
+```javascript
+Simulado.mock({
+  path: "/[^\?]\?username=/",
+  status: 200,
+  headers: {"Content-Type": 'application/json'},
+  response: {
+    id: 123,
+    type: "MOBILE",
+    name: "My work phone"
+  }
+})
+```
 
 ### Mocks
 If you want to mock out multiple requests at once you can use the `mocks` function.

--- a/lib/responseStore.js
+++ b/lib/responseStore.js
@@ -31,7 +31,7 @@ var ResponseStore = {
         if (mocks[baseMock.method] == undefined) {
             mocks[baseMock.method] = {}
         }
-      
+
         if (mocks[baseMock.method][baseMock.path] == undefined) {
             mocks[baseMock.method][baseMock.path] = []
         }
@@ -115,11 +115,17 @@ function findByPath(httpMethod, requestedPath) {
 }
 
 function requestedPathMatchesMockPath(requestedPath, mockPath) {
-  var mockPathRegex = mockPath;
-  if(!_.isRegExp(mockPathRegex) && _.isString(mockPathRegex)) {
-    mockPathRegex = new RegExp(mockPathRegex.replace(/\//g, '\/').replace(/\?/g, '\\?').replace('*', '.*'));
+  var mockPathRegex;
+  if(_.isRegExp(mockPath)) {
+    mockPathRegex = mockPath;
+  } else if(_.isString(mockPath)) {
+    if(!/^\/.+\/$/.test(mockPath)) {
+      mockPathRegex = new RegExp(mockPath.replace(/\//g, '\/').replace(/\?/g, '\\?').replace('*', '.*'));
+    } else {
+      mockPathRegex = new RegExp(mockPath.replace(/^\//, '').replace(/\/$/, ''));
+    }
   }
-  return mockPathRegex.test(requestedPath);
+  return mockPathRegex && mockPathRegex.test(requestedPath);
 }
 
 function findByConditionalRequest(possibleMocks, request) {

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -156,6 +156,19 @@ describe('Simulado', function() {
           });
         });
 
+        it('should respond to stringified regexp path', function(done) {
+            Simulado.mock({
+                path: '/[^\?].*\?[^&]*?&?fred=[^&]*/',
+                status: 200,
+                response: 'some data'
+            }, function() {
+                superagent.get('http://localhost:7000/test/path?fred=jim').end(function(_, res) {
+                    res.text.should.equal('some data');
+                    done()
+                });
+          });
+        });
+
         it('should respond to more exact matches over regex', function (done) {
             Simulado.mock({
                 path: '/test/path',


### PR DESCRIPTION
Here's what I can propose to manage stringified regexes.
However there's a restriction: since we test if the path is surrounded by slashes, a full path with the same pattern will be parsed as a regex.
I added a line in the readme to explicit that issue.