### PR TITLE
Update memory limit for v2

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ var path = require('path');
 
 var Server = function() {
   app.use(cors());
-  app.use(bodyParser.json({limit: '1mb'}));
+  app.use(bodyParser.json({limit: '50mb'}));
   app.use(bodyParser.urlencoded({
       extended: true
   }));


### PR DESCRIPTION
Hey mate is v2 still supported? I've just updated the memory limit to align with your v3 version.

Some request bodies are blowing up the server so it would be good to get this change in :)

I looked at the v3 branch but it doesn't have a like for like api methods for `syncMocks` and `syncDefaults`. Happy to contribute to v3 when I get the time!