### PR TITLE
Update v2 to include origin/credentials for CORS 

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var requestStore = require('./lib/requestStore');
 var path = require('path');
 
 var Server = function() {
-  app.use(cors());
+  app.use(cors({ origin: true, credentials: true }));
   app.use(bodyParser.json({limit: '50mb'}));
   app.use(bodyParser.urlencoded({
       extended: true


### PR DESCRIPTION
This change has been made because at the moment the `OPTIONS` request in Simulado v2 returns a wildcard (`*`) by default. 

When you've got a request with credentials, the browser will refuse to load it due to the wildcard. We need to pass the correct host info back. 

By setting `origin` to `true` and `credentials` to `true`, we'll get the correct headers back to allow the request to proceed. (Basically just ported over from master :)) 

(Sorry - still on v2 unfortunately!) 